### PR TITLE
EDB and keycloak size configuration

### DIFF
--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -846,27 +846,37 @@ const ConfigurationRules = `
     apicatalogmanager:
       profile: LARGEST_VALUE
 - name: edb-keycloak
-  spec:
-    Cluster:
-      resources:
-        requests:
-          cpu: LARGEST_VALUE
-          memory: LARGEST_VALUE
-        limits:
-          cpu: LARGEST_VALUE
-          memory: LARGEST_VALUE
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: LARGEST_VALUE
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: LARGEST_VALUE
-                    memory: LARGEST_VALUE
-                  requests:
-                    cpu: LARGEST_VALUE
-                    memory: LARGEST_VALUE
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: LARGEST_VALUE
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: LARGEST_VALUE
+                      memory: LARGEST_VALUE
+                    requests:
+                      cpu: LARGEST_VALUE
+                      memory: LARGEST_VALUE
 `

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -675,29 +675,37 @@ const Large = `
     apicatalogmanager:
       profile: large
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 3
-      resources:
-        requests:
-          cpu: 750m
-          memory: 1500Mi
-        limits:
-          cpu: 750m
-          memory: 1500Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 3
+        resources:
+          limits:
+            cpu: 750m
+            memory: 1500Mi
+          requests:
+            cpu: 750m
+            memory: 1500Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 3
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 3
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -675,29 +675,37 @@ const Large = `
     apicatalogmanager:
       profile: large
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 3
-      resources:
-        requests:
-          cpu: 750m
-          memory: 1500Mi
-        limits:
-          cpu: 750m
-          memory: 1500Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 3
+        resources:
+          limits:
+            cpu: 750m
+            memory: 1500Mi
+          requests:
+            cpu: 750m
+            memory: 1500Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 3
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 3
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -675,29 +675,37 @@ const Large = `
     apicatalogmanager:
       profile: large
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 3
-      resources:
-        requests:
-          cpu: 750m
-          memory: 1500Mi
-        limits:
-          cpu: 750m
-          memory: 1500Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 3
+        resources:
+          limits:
+            cpu: 750m
+            memory: 1500Mi
+          requests:
+            cpu: 750m
+            memory: 1500Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 3
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 3
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -675,29 +675,37 @@ const Medium = `
     apicatalogmanager:
       profile: medium
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 2
-      resources:
-        requests:
-          cpu: 500m
-          memory: 1024Mi
-        limits:
-          cpu: 500m
-          memory: 1024Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1024Mi
+          requests:
+            cpu: 500m
+            memory: 1024Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 2
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 2
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -675,29 +675,37 @@ const Medium = `
     apicatalogmanager:
       profile: medium
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 2
-      resources:
-        requests:
-          cpu: 500m
-          memory: 1024Mi
-        limits:
-          cpu: 500m
-          memory: 1024Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1024Mi
+          requests:
+            cpu: 500m
+            memory: 1024Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 2
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 2
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -675,29 +675,37 @@ const Medium = `
     apicatalogmanager:
       profile: medium
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 2
-      resources:
-        requests:
-          cpu: 500m
-          memory: 1024Mi
-        limits:
-          cpu: 500m
-          memory: 1024Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1024Mi
+          requests:
+            cpu: 500m
+            memory: 1024Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 2
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 2
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -675,29 +675,37 @@ const Small = `
     apicatalogmanager:
       profile: small
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 1
-      resources:
-        requests:
-          cpu: 200m
-          memory: 768Mi
-        limits:
-          cpu: 200m
-          memory: 768Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 200m
+            memory: 768Mi
+          requests:
+            cpu: 200m
+            memory: 768Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 2
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 2
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -675,29 +675,37 @@ const Small = `
     apicatalogmanager:
       profile: small
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 1
-      resources:
-        requests:
-          cpu: 200m
-          memory: 768Mi
-        limits:
-          cpu: 200m
-          memory: 768Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 200m
+            memory: 768Mi
+          requests:
+            cpu: 200m
+            memory: 768Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 2
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 2
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -675,29 +675,37 @@ const Small = `
     apicatalogmanager:
       profile: small
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 1
-      resources:
-        requests:
-          cpu: 200m
-          memory: 768Mi
-        limits:
-          cpu: 200m
-          memory: 768Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 200m
+            memory: 768Mi
+          requests:
+            cpu: 200m
+            memory: 768Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 2
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 2
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -675,29 +675,37 @@ const StarterSet = `
     apicatalogmanager:
       profile: small
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 1
-      resources:
-        requests:
-          cpu: 200m
-          memory: 512Mi
-        limits:
-          cpu: 200m
-          memory: 512Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 200m
+            memory: 512Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 1
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 1
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -675,29 +675,37 @@ const StarterSet = `
     apicatalogmanager:
       profile: small
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 1
-      resources:
-        requests:
-          cpu: 200m
-          memory: 512Mi
-        limits:
-          cpu: 200m
-          memory: 512Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 200m
+            memory: 512Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 1
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 1
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -677,29 +677,37 @@ const StarterSet = `
     apicatalogmanager:
       profile: small
 - name: edb-keycloak
-  spec:
-    Cluster:
-      instances: 1
-      resources:
-        requests:
-          cpu: 200m
-          memory: 512Mi
-        limits:
-          cpu: 200m
-          memory: 512Mi
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: keycloak-edb-cluster
+    data:
+      spec:
+        instances: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 200m
+            memory: 512Mi
 - name: keycloak-operator
-  spec:
-    Keycloak:
-      instances: 1
-      unsupported:
-        podTemplate:
-          spec:
-            containers:
-              - resources:
-                  limits:
-                    cpu: 1000m
-                    memory: 1Gi
-                  requests:
-                    cpu: 1000m
-                    memory: 1Gi
+  resources:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    kind: Keycloak
+    name: cs-keycloak
+    data:
+      spec:
+        instances: 1
+        unsupported:
+          podTemplate:
+            spec:
+              containers:
+                - resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 1Gi
+                    requests:
+                      cpu: 1000m
+                      memory: 1Gi
 `


### PR DESCRIPTION
EDB and KeyCloak size configuration could be created or edited in CS CR according to the [Option one](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60915#issuecomment-66114829)

#### Following the template:
```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: common-service
spec:
  ...
  services:
   - name: keycloak-operator
     resources:
      - apiVersion: k8s.keycloak.org/v2alpha1
        kind: Keycloak
        name: cs-keycloak
        data:
          spec:
            instances: 1
            unsupported:
              podTemplate:
                spec:
                  containers:
                    - resources:
                        limits:
                          cpu: 1000m
                          memory: 1Gi
                        requests:
                          cpu: 1000m
                          memory: 1Gi
   - name: edb-keycloak
     resources:
      - apiVersion: postgresql.k8s.enterprisedb.io/v1
        kind: Cluster
        name: keycloak-edb-cluster
        data:
          spec:
            instances: 3
            resources:
              limits:
                cpu: 3000m
                memory: 3Gi
              requests:
                cpu: 1000m
                memory: 1Gi
```
